### PR TITLE
Fix SigV4 region logic: ensure AWS region fallback

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -6,13 +6,13 @@
 # ═══════════════════════════════════════════════════════════
 AWS_REGION=us-east-2
 AWS_ACCOUNT_ID=703671891952
+VITE_AWS_REGION=us-east-2
 
 # ═══════════════════════════════════════════════════════════
 # 🚀 VITE APPLICATION SETTINGS (Production Mode)
 # ═══════════════════════════════════════════════════════════
 VITE_COUNTER=3
 VITE_API_BASE_URL=https://q2b9avfwv5.execute-api.us-east-2.amazonaws.com/prod
-VITE_AWS_REGION=us-east-2
 VITE_COGNITO_REGION=us-east-2
 VITE_COGNITO_POOL_ID=us-east-2_FyHLtOhiY
 VITE_COGNITO_WEB_CLIENT=dshos5iou44tuach7ta3ici5m

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -21,6 +21,7 @@ env:
   AWS_REGION: us-east-2
   CLOUDFRONT_DOMAIN: d7t9x3j66yd8k.cloudfront.net
   HEALTH_URL: https://d7t9x3j66yd8k.cloudfront.net/health   # simple /health route
+  VITE_AWS_REGION: us-east-2
 
 permissions:
   contents: read

--- a/.github/workflows/dependencies-update.yml
+++ b/.github/workflows/dependencies-update.yml
@@ -51,11 +51,13 @@ jobs:
       - name: Build (CI)
         env:
           CI: '1'
+          VITE_AWS_REGION: us-east-2
         run: pnpm run build
 
       - name: Build Storybook
         env:
           CI: '1'
+          VITE_AWS_REGION: us-east-2
         run: pnpm run build:storybook || true
 
       - name: Run command

--- a/.github/workflows/deploy-lambda-fixes.yml
+++ b/.github/workflows/deploy-lambda-fixes.yml
@@ -64,6 +64,8 @@ jobs:
         run: npm ci
 
       - name: Build frontend with API fixes
+        env:
+          VITE_AWS_REGION: us-east-2
         run: npm run build
 
       - name: Configure AWS credentials

--- a/.github/workflows/deploy-ui-prod.yml
+++ b/.github/workflows/deploy-ui-prod.yml
@@ -12,6 +12,7 @@ env:                      # ---------- Global env ----------
   API_ID:      ${{ secrets.ACTA_API_ID }}
   API_ROOT_ID: ${{ secrets.ACTA_API_ROOT_ID }}
   API_STAGE:   prod
+  VITE_AWS_REGION: us-east-2
 # -----------------------------------------------------------
 
 jobs:

--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main, develop]
 
+env:
+  VITE_AWS_REGION: us-east-2
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/src/utils/fetchWrapper.ts
+++ b/src/utils/fetchWrapper.ts
@@ -8,6 +8,11 @@ import { HttpRequest } from "@smithy/protocol-http";
 import { parseUrl } from "@smithy/url-parser";
 import { FetchHttpHandler } from "@smithy/fetch-http-handler";
 
+const region =
+  import.meta.env.VITE_AWS_REGION ||
+  import.meta.env.VITE_COGNITO_REGION ||
+  "us-east-2";
+
 const sigv4Endpoints = [
   "/projects-for-pm",
   "/send-approval-email",
@@ -61,10 +66,7 @@ export async function fetcher<T>(input: RequestInfo, init?: RequestInit): Promis
 
     const signer = new SignatureV4({
       service: "execute-api",
-      region:
-        import.meta.env.VITE_AWS_REGION ||
-        import.meta.env.VITE_COGNITO_REGION ||
-        "us-east-2",
+      region,
       credentials: {
         accessKeyId: creds.accessKeyId,
         secretAccessKey: creds.secretAccessKey,


### PR DESCRIPTION
## Summary
- ensure SigV4 signer falls back to `VITE_AWS_REGION`, `VITE_COGNITO_REGION`, or `us-east-2`
- add `VITE_AWS_REGION` to production env and CI workflows

## Testing
- `pnpm exec eslint . --max-warnings=0` *(fails: 827 problems)*
- `pnpm exec tsc --noEmit`
- `pnpm run build`
- `pnpm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6891b255b5948324994251ac0d0f184e