### PR TITLE
Restore Amplify login configuration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -128,10 +128,7 @@ export default function App() {
           path="/"
           element={<Navigate to={skipAuth || isAuthed ? '/dashboard' : '/login'} />}
         />
-        <Route
-          path="/login"
-          element={skipAuth || isAuthed ? <Navigate to="/dashboard" /> : <Login />}
-        />
+        <Route path="/login" element={<Login />} />
         <Route
           path="/dashboard"
           element={skipAuth || isAuthed ? <Dashboard /> : <Navigate to="/login" />}

--- a/src/aws-exports.js
+++ b/src/aws-exports.js
@@ -1,26 +1,41 @@
-export default {
-  aws_project_region: "us-east-2",
-  aws_cognito_region: "us-east-2",
-  aws_user_pools_id: "us-east-2_FyHLtOhiY",
-  aws_user_pools_web_client_id: "dshos5iou44tuach7ta3ici5m",
-  aws_cognito_identity_pool_id:
-    "us-east-2:1d50fa9e-c72f-4a3d-acfd-7b36ea065f35",
-  oauth: {
-    domain: "us-east-2-fyhltohiy.auth.us-east-2.amazoncognito.com",
-    scope: ["email", "openid", "profile"],
-    redirectSignIn: "https://d7t9x3j66yd8k.cloudfront.net/",
-    redirectSignOut: "https://d7t9x3j66yd8k.cloudfront.net/login",
-    responseType: "code"
+const awsmobile = {
+  aws_project_region: 'us-east-2',
+  aws_cognito_region: 'us-east-2',
+
+  aws_user_pools_id: 'us-east-2_FyHLtOhiY',
+  aws_user_pools_web_client_id: 'dshos5iou44tuach7ta3ici5m',
+
+  aws_cognito_identity_pool_id: 'us-east-2:1d50fa9e-c72f-4a3d-acfd-7b36ea065f35',
+
+  Auth: {
+    region: 'us-east-2',
+    userPoolId: 'us-east-2_FyHLtOhiY',
+    userPoolWebClientId: 'dshos5iou44tuach7ta3ici5m',
+    identityPoolId: 'us-east-2:1d50fa9e-c72f-4a3d-acfd-7b36ea065f35',
+    authenticationFlowType: 'USER_SRP_AUTH',
+    mandatorySignIn: true
   },
+
+  oauth: {
+    domain: 'us-east-2-fyhltohiy.auth.us-east-2.amazoncognito.com',
+    scope: ['email', 'openid', 'profile'],
+    redirectSignIn: 'https://d7t9x3j66yd8k.cloudfront.net/',
+    redirectSignOut: 'https://d7t9x3j66yd8k.cloudfront.net/login',
+    responseType: 'code'
+  },
+
   API: {
     REST: {
       ActaAPI: {
-        endpoint: "https://q2b9avfwv5.execute-api.us-east-2.amazonaws.com/prod",
-        region: "us-east-2"
+        endpoint: 'https://q2b9avfwv5.execute-api.us-east-2.amazonaws.com/prod',
+        region: 'us-east-2'
       }
     }
   },
+
   Storage: {
-    S3: { bucket: "projectplace-dv-2025-x9a7b", region: "us-east-2" }
+    S3: { bucket: 'projectplace-dv-2025-x9a7b', region: 'us-east-2' }
   }
 };
+
+export default awsmobile;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,44 +4,21 @@ import '@/tailwind.css';
 import '@aws-amplify/ui-react/styles.css';
 
 import { Amplify } from 'aws-amplify';
+
+import awsExports from './aws-exports';
+
+Amplify.configure(awsExports);
+
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 
 import App from '@/App';
 
-async function loadAwsConfig() {
-  if ((window as any).awsmobile) return (window as any).awsmobile;
-
-  await new Promise((resolve) => {
-    const timer = setTimeout(resolve, 5000);
-    window.addEventListener(
-      'awsmobile-loaded',
-      () => {
-        clearTimeout(timer);
-        resolve(null);
-      },
-      { once: true }
-    );
-  });
-
-  if ((window as any).awsmobile) return (window as any).awsmobile;
-
-  const cfg = await import('@/aws-exports');
-  return cfg.default || cfg;
-}
-
-async function init() {
-  const config = await loadAwsConfig();
-  Amplify.configure(config);
-
-  createRoot(document.getElementById('root')).render(
-    <React.StrictMode>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </React.StrictMode>
-  );
-}
-
-init();
+createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- configure Amplify during app startup using `aws-exports`
- restore full AWS configuration including Auth and API sections
- register `/login` route and ensure unauthenticated fallback

## Testing
- `pnpm exec eslint src/main.tsx src/aws-exports.js src/App.tsx`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689428a6bf5883249a7ec9b742952d6d