### PR TITLE
fix: add Identity Pool credential handling for SigV4 requests

### DIFF
--- a/src/api-amplify.ts
+++ b/src/api-amplify.ts
@@ -1,7 +1,7 @@
 // import { Auth } from 'aws-amplify';rc/lib/api-amplify.ts
 // Enhanced API client with AWS Amplify authentication integration
 
-import { fetchAuthSession } from 'aws-amplify/auth';
+import { fetchAuthSession, getCredentials } from 'aws-amplify';
 
 import { apiBaseUrl, skipAuth } from '@/env.variables';
 
@@ -22,6 +22,11 @@ export const apiCall = async (
   const { timeout = 30000, headers = {}, skipAuth: skipAuthOption = false } = options || {};
 
   try {
+    const creds = await getCredentials();
+    if (!creds?.identityId) {
+      throw new Error('Missing identity ID for SigV4 request');
+    }
+
     // Prepare headers
     const requestHeaders: Record<string, string> = {
       'Content-Type': 'application/json',

--- a/src/lib/api-amplify.ts
+++ b/src/lib/api-amplify.ts
@@ -1,7 +1,7 @@
 // import { Auth } from 'aws-amplify';rc/lib/api-amplify.ts
 // Enhanced API client with AWS Amplify authentication integration
 
-import { fetchAuthSession } from 'aws-amplify/auth';
+import { fetchAuthSession, getCredentials } from 'aws-amplify';
 
 import { apiBaseUrl, skipAuth } from '@/env.variables';
 
@@ -22,6 +22,11 @@ export const apiCall = async (
   const { timeout = 30000, headers = {}, skipAuth: skipAuthOption = false } = options || {};
 
   try {
+    const creds = await getCredentials();
+    if (!creds?.identityId) {
+      throw new Error('Missing identity ID for SigV4 request');
+    }
+
     // Prepare headers
     const requestHeaders: Record<string, string> = {
       'Content-Type': 'application/json',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,7 @@ import '@/styles/variables.css';
 import '@/styles/amplify-overrides.css';
 import '@aws-amplify/ui-react/styles.css';
 
-import { Amplify } from 'aws-amplify';
+import { Amplify, fetchAuthSession, getCredentials } from 'aws-amplify';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
@@ -14,12 +14,24 @@ import awsExports from './aws-exports';
 
 let amplifyConfigured = false;
 
+const initializeIdentity = async () => {
+  try {
+    await fetchAuthSession();
+    const credentials = await getCredentials();
+    (window as any).identityId = credentials?.identityId;
+    console.log('🧠 Identity ID:', credentials?.identityId);
+  } catch (err) {
+    console.error('❌ Identity resolution failed', err);
+  }
+};
+
 const configureAmplify = async () => {
   if (amplifyConfigured) return;
 
   try {
     const config = (window as any).awsmobile || awsExports;
     Amplify.configure(config);
+    await initializeIdentity();
     amplifyConfigured = true;
     console.log('✅ Amplify configured with:', config);
     console.log('Amplify Identity Pool:', config.aws_cognito_identity_pool_id);


### PR DESCRIPTION
## Summary
- load Cognito Identity Pool credentials during app startup to expose identity ID
- ensure API client waits for Identity Pool credentials and throws if missing

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68943891901c83248355e54f7d1c3fd6