### PR TITLE
dev: add global Auth debugger

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import '@/styles/amplify-overrides.css';
 import '@aws-amplify/ui-react/styles.css';
 
 import { Amplify } from 'aws-amplify';
+import { fetchAuthSession } from 'aws-amplify/auth';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
@@ -11,6 +12,22 @@ import { BrowserRouter } from 'react-router-dom';
 import App from '@/App';
 
 import awsExports from './aws-exports';
+
+declare global {
+  interface Window {
+    debugAuth?: () => void;
+  }
+}
+
+window.debugAuth = async () => {
+  try {
+    const session = await fetchAuthSession({ forceRefresh: true });
+    console.log('🧠 Auth Session:', session);
+    console.log('🧠 Identity ID:', (session?.credentials as any)?.identityId);
+  } catch (err) {
+    console.error('❌ Auth debug failed:', err);
+  }
+};
 
 let amplifyConfigured = false;
 


### PR DESCRIPTION
## Summary
- expose `window.debugAuth` for logging auth session and identity

## Testing
- `pnpm lint`
- `pnpm run type-check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6894394b6f6083249d8ad1b635b964d3