### PR TITLE
fix: add Identity Pool credential handling for SigV4 requests

### DIFF
--- a/src/api-amplify.ts
+++ b/src/api-amplify.ts
@@ -1,6 +1,7 @@
 // import { Auth } from 'aws-amplify';rc/lib/api-amplify.ts
 // Enhanced API client with AWS Amplify authentication integration
 
+import { getCredentials } from 'aws-amplify';
 import { fetchAuthSession } from 'aws-amplify/auth';
 
 import { apiBaseUrl, skipAuth } from '@/env.variables';
@@ -22,6 +23,11 @@ export const apiCall = async (
   const { timeout = 30000, headers = {}, skipAuth: skipAuthOption = false } = options || {};
 
   try {
+    const creds = await getCredentials();
+    if (!creds?.identityId) {
+      throw new Error('Missing identity ID for SigV4 request');
+    }
+
     // Prepare headers
     const requestHeaders: Record<string, string> = {
       'Content-Type': 'application/json',

--- a/src/lib/api-amplify.ts
+++ b/src/lib/api-amplify.ts
@@ -1,6 +1,7 @@
 // import { Auth } from 'aws-amplify';rc/lib/api-amplify.ts
 // Enhanced API client with AWS Amplify authentication integration
 
+import { getCredentials } from 'aws-amplify';
 import { fetchAuthSession } from 'aws-amplify/auth';
 
 import { apiBaseUrl, skipAuth } from '@/env.variables';
@@ -22,6 +23,11 @@ export const apiCall = async (
   const { timeout = 30000, headers = {}, skipAuth: skipAuthOption = false } = options || {};
 
   try {
+    const creds = await getCredentials();
+    if (!creds?.identityId) {
+      throw new Error('Missing identity ID for SigV4 request');
+    }
+
     // Prepare headers
     const requestHeaders: Record<string, string> = {
       'Content-Type': 'application/json',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,7 @@ import '@/styles/variables.css';
 import '@/styles/amplify-overrides.css';
 import '@aws-amplify/ui-react/styles.css';
 
-import { Amplify } from 'aws-amplify';
+import { Amplify, fetchAuthSession, getCredentials } from 'aws-amplify';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
@@ -28,8 +28,20 @@ const configureAmplify = async () => {
   }
 };
 
+const initializeIdentity = async () => {
+  try {
+    await fetchAuthSession();
+    const credentials = await getCredentials();
+    console.log('🧠 Identity ID:', credentials?.identityId);
+    (window as any).identityId = credentials?.identityId;
+  } catch (err) {
+    console.error('❌ Identity resolution failed', err);
+  }
+};
+
 async function init() {
   await configureAmplify();
+  await initializeIdentity();
 
   createRoot(document.getElementById('root')!).render(
     <React.StrictMode>

--- a/src/utils/fetchWrapper.ts
+++ b/src/utils/fetchWrapper.ts
@@ -5,6 +5,7 @@ import { FetchHttpHandler } from '@smithy/fetch-http-handler';
 import { HttpRequest } from '@smithy/protocol-http';
 import { SignatureV4 } from '@smithy/signature-v4';
 import { parseUrl } from '@smithy/url-parser';
+import { getCredentials } from 'aws-amplify';
 import { fetchAuthSession } from 'aws-amplify/auth';
 
 import { skipAuth } from '@/env.variables';
@@ -57,6 +58,10 @@ export async function fetcher<T>(input: RequestInfo, init?: RequestInit): Promis
   const url = typeof input === 'string' ? input : input.url;
 
   if (needsSigV4(url)) {
+    const credsLoaded = await getCredentials();
+    if (!credsLoaded?.identityId) {
+      throw new Error('Missing identity ID for SigV4 request');
+    }
     const session = await fetchAuthSession();
     const creds = session.credentials;
 


### PR DESCRIPTION
## Summary
- initialize Cognito Identity Pool credentials on app start
- guard API calls with getCredentials and identityId validation
- enforce identity check before SigV4 signing in fetch wrapper

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68943a09aa048324908335bb0620ad43