### PR TITLE
Wire ACTA buttons to production APIs

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -34,12 +34,17 @@ async function request<T = unknown>(
 ): Promise<T> {
   const url = `${BASE}${endpoint}`;
 
-  console.log('🌐 Making SigV4-signed request to:', url, {
-    method: options.method || 'GET',
-  });
+  const body = options.body ? JSON.parse(options.body as string) : undefined;
+
+  if (import.meta.env.DEV) {
+    console.log('🌐 Request:', url, {
+      method: options.method || 'GET',
+      payload: body,
+    });
+  }
 
   if (options.method === 'POST') {
-    return post<T>(url, options.body ? JSON.parse(options.body as string) : undefined);
+    return post<T>(url, body);
   } else {
     return get<T>(url);
   }
@@ -95,20 +100,20 @@ export async function generateActaDocument(
 /** -------------------------------------------------------------------------
  * 🏗️ 2 & 3. Download DOCX / PDF
  * --------------------------------------------------------------------------*/
-export async function getSignedDownloadUrl(
+export async function getS3DownloadUrl(
   projectId: string,
   format: 'pdf' | 'docx'
 ): Promise<string> {
   const url = `${BASE}/download-acta/${projectId}?format=${format}`;
 
-  console.log('🔗 Getting download URL for:', url);
+  if (import.meta.env.DEV) {
+    console.log('🔗 Getting download URL for:', url);
+  }
 
-  // Use fetchWrapper for proper SigV4 signing
   const response = await fetcher<{ downloadUrl?: string; url?: string }>(url, {
     method: 'GET',
   });
 
-  // Handle different response formats
   if (typeof response === 'string') {
     return response;
   }
@@ -123,10 +128,10 @@ export async function getSignedDownloadUrl(
 /** -------------------------------------------------------------------------
  * 🏗️ 4. Send approval e‑mail to client
  * --------------------------------------------------------------------------*/
-export const sendApprovalEmail = (actaId: string, clientEmail: string) =>
+export const sendApprovalEmail = (projectId: string, recipientEmail: string) =>
   request<{ message: string }>(`/send-approval-email`, {
     method: 'POST',
-    body: JSON.stringify({ actaId, clientEmail }),
+    body: JSON.stringify({ projectId, recipientEmail }),
   });
 
 export interface DocumentCheckResult {
@@ -145,6 +150,9 @@ export async function documentExists(
 ): Promise<DocumentCheckResult> {
   try {
     const url = `${BASE}/check-document/${projectId}?format=${format}`;
+    if (import.meta.env.DEV) {
+      console.log('🔍 Checking document:', url);
+    }
     const response = await fetcher<DocumentCheckResult>(url, {
       method: 'GET',
     });
@@ -173,7 +181,7 @@ export interface PMProject {
 }
 
 export const checkDocumentInS3 = documentExists;
-export const getDownloadUrl = getSignedDownloadUrl;
+export const getDownloadUrl = getS3DownloadUrl;
 export const checkDocumentAvailability = documentExists;
 
 export async function getProjectsByPM(pmEmail: string, isAdmin: boolean): Promise<PMProject[]> {
@@ -206,7 +214,7 @@ if (import.meta.env.DEV && typeof window !== 'undefined') {
   window.__actaApi = {
     ping: () => request<{ status: string }>('/health', { auth: false }),
     generateActaDocument,
-    getSignedDownloadUrl,
+    getS3DownloadUrl,
     documentExists,
     sendApprovalEmail,
     getSummary,

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -14,7 +14,7 @@ import { useMetrics } from '@/hooks/useMetrics';
 import {
   checkDocumentInS3,
   generateActaDocument,
-  getDownloadUrl,
+  getS3DownloadUrl,
   sendApprovalEmail,
 } from '@/lib/api';
 
@@ -88,7 +88,7 @@ export default function Dashboard() {
     
     try {
       const url = await trackAction(`Download ${format.toUpperCase()}`, selectedProjectId, async () => {
-        return await getDownloadUrl(selectedProjectId, format);
+        return await getS3DownloadUrl(selectedProjectId, format);
       });
       
       window.open(url, '_blank');
@@ -124,7 +124,7 @@ export default function Dashboard() {
         if (!check.available) {
           throw new Error('Document not ready, try Generate first.');
         }
-        const url = await getDownloadUrl(selectedProjectId, 'pdf');
+        const url = await getS3DownloadUrl(selectedProjectId, 'pdf');
         setPdfPreviewUrl(url);
         setPdfPreviewFileName(`acta-${selectedProjectId}.pdf`);
         return url;

--- a/src/utils/fetchWrapper.ts
+++ b/src/utils/fetchWrapper.ts
@@ -55,6 +55,7 @@ export async function getAuthToken(): Promise<string | null> {
 
 export async function fetcher<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
   const url = typeof input === 'string' ? input : input.url;
+  const token = await getAuthToken();
 
   if (needsSigV4(url)) {
     const session = await fetchAuthSession();
@@ -75,6 +76,10 @@ export async function fetcher<T>(input: RequestInfo, init?: RequestInit): Promis
     const headerRecord: Record<string, string> = {
       host: parsed.hostname,
     };
+
+    if (token) {
+      headerRecord['Authorization'] = `Bearer ${token}`;
+    }
 
     if (init?.headers) {
       const headers = init.headers;
@@ -113,7 +118,6 @@ export async function fetcher<T>(input: RequestInfo, init?: RequestInit): Promis
       throw new Error('Invalid JSON response from SigV4 request');
     }
   } else {
-    const token = await getAuthToken();
     const headers = new Headers(init?.headers);
     if (token) headers.set('Authorization', `Bearer ${token}`);
     if (!headers.has('Content-Type') && init?.method !== 'GET') {


### PR DESCRIPTION
## Summary
- log request URL and payload and route ACTA actions to production endpoints
- add auth header to SigV4 requests and expose S3 download helpers
- use S3 download helper for PDF/DOCX actions on dashboard

## Testing
- `pnpm test` *(fails: Cannot find module '../../lib/api')*
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68957521728c8324ba35841f92d3df65