### PR TITLE
Wire ACTA buttons to production API

### DIFF
--- a/src/components/ActaButtons.tsx
+++ b/src/components/ActaButtons.tsx
@@ -3,6 +3,9 @@ import { Download, Eye, FileText, Send } from 'lucide-react';
 
 import Button from '@/components/Button';
 
+// Loading gates inside this component prevent API calls while actions
+// are already in progress or the buttons are disabled.
+
 export interface ActaButtonsProps {
   onGenerate: () => void;
   onDownloadWord: () => void;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,10 +1,6 @@
-// src/lib/api.ts – Unified API helper for ACTA‑UI buttons
-// -----------------------------------------------------------
-// This **replaces** every previous version of api.ts in the repo. It wires the
-// five priority endpoints (Generate, Download PDF/DOCX, Preview PDF, Send
-// Approval, Check status) and makes sure all requests include a fresh Cognito
-// JWT. Any component can now just import the functions below.
-// -----------------------------------------------------------
+// Unified API helpers for ACTA UI buttons and dashboard flows
+// Endpoint base and AWS configuration are taken from environment variables
+// to keep the code contract-safe and production ready.
 
 import {
   apiBaseUrl,
@@ -15,54 +11,16 @@ import {
 } from '@/env.variables';
 import { fetcher, get, post } from '@/utils/fetchWrapper';
 
-/**
- * ---------------------------------------------------------------------------
- *  🔧 GLOBAL CONSTANTS
- * ---------------------------------------------------------------------------
- */
-export const BASE = apiBaseUrl || 'https://q2b9avfwv5.execute-api.us-east-2.amazonaws.com/prod';
+import { getDownloadUrl as getS3PresignedUrl } from './awsDataService';
 
+export const BASE =
+  apiBaseUrl || 'https://q2b9avfwv5.execute-api.us-east-2.amazonaws.com/prod';
 export const S3_BUCKET = s3Bucket || 'projectplace-dv-2025-x9a7b';
 export const AWS_REGION = s3Region || 'us-east-2';
 
-/** -------------------------------------------------------------------------
- * 🛠️ Utility – signed / authorised fetch using SigV4-enabled fetchWrapper
- * --------------------------------------------------------------------------*/
-async function request<T = unknown>(
-  endpoint: string,
-  options: RequestInit & { auth?: boolean } = {}
-): Promise<T> {
-  const url = `${BASE}${endpoint}`;
-
-  let body: unknown = undefined;
-  if (options.body) {
-    try {
-      body = JSON.parse(options.body as string);
-    } catch (err) {
-      if (import.meta.env.DEV) {
-        console.error('❌ Failed to parse request body as JSON:', options.body, err);
-      }
-      body = undefined;
-    }
-  }
-
-  if (import.meta.env.DEV) {
-    console.log('🌐 Request:', url, {
-      method: options.method || 'GET',
-      payload: body,
-    });
-  }
-
-  if (options.method === 'POST') {
-    return post<T>(url, body);
-  } else {
-    return get<T>(url);
-  }
-}
-
-/** -------------------------------------------------------------------------
- * 📘 Project metadata helpers (optional)
- * --------------------------------------------------------------------------*/
+/** -----------------------------------------------------------------------
+ * Project metadata helpers
+ * -------------------------------------------------------------------- */
 export interface ProjectSummary {
   project_id: string;
   project_name: string;
@@ -70,22 +28,26 @@ export interface ProjectSummary {
   project_manager?: string;
   [k: string]: unknown;
 }
+
 export interface TimelineEvent {
   hito: string;
   actividades: string;
   desarrollo: string;
   fecha: string;
 }
-export const getSummary = (id: string) => request<ProjectSummary>(`/project-summary/${id}`);
-export const getTimeline = (id: string) => request<TimelineEvent[]>(`/timeline/${id}`);
 
-/** -------------------------------------------------------------------------
- * 🏗️ 1. Generate ACTA (DOCX+PDF)
- * --------------------------------------------------------------------------*/
+export const getSummary = (id: string) =>
+  get<ProjectSummary>(`${BASE}/project-summary/${id}`);
+export const getTimeline = (id: string) =>
+  get<TimelineEvent[]>(`${BASE}/timeline/${id}`);
+
+/** -----------------------------------------------------------------------
+ * Generate ACTA document
+ * -------------------------------------------------------------------- */
 export async function generateActaDocument(
   projectId: string,
-  userEmail: string,
-  userRole: 'pm' | 'admin' = 'pm'
+  userEmail?: string,
+  userRole: 'pm' | 'admin' = 'pm',
 ) {
   const payload = {
     projectId,
@@ -93,57 +55,81 @@ export async function generateActaDocument(
     userRole,
     s3Bucket: S3_BUCKET,
     s3Region: AWS_REGION,
-    cloudfrontDistributionId: cloudfrontDistributionId || 'EPQU7PVDLQXUA',
-    cloudfrontUrl: cloudfrontUrl || 'https://d7t9x3j66yd8k.cloudfront.net',
+    cloudfrontDistributionId,
+    cloudfrontUrl,
     requestSource: 'acta-ui',
     generateDocuments: true,
     extractMetadata: true,
     timestamp: new Date().toISOString(),
   };
 
-  return request<{ message: string; success: boolean }>(`/extract-project-place/${projectId}`, {
-    method: 'POST',
-    body: JSON.stringify(payload),
-  });
+  return post<{ message: string; success: boolean }>(
+    `${BASE}/extract-project-place/${projectId}`,
+    payload,
+  );
 }
 
-/** -------------------------------------------------------------------------
- * 🏗️ 2 & 3. Download DOCX / PDF
- * --------------------------------------------------------------------------*/
-export async function getS3DownloadUrl(
+/** -----------------------------------------------------------------------
+ * Download links (PDF or DOCX)
+ * -------------------------------------------------------------------- */
+export async function getDownloadLink(
   projectId: string,
-  format: 'pdf' | 'docx'
+  format: 'pdf' | 'docx',
 ): Promise<string> {
   const url = `${BASE}/download-acta/${projectId}?format=${format}`;
-
-  if (import.meta.env.DEV) {
-    console.log('🔗 Getting download URL for:', url);
-  }
-
-  const response = await fetcher<{ downloadUrl?: string; url?: string }>(url, {
+  const response = await fetcher<{ url?: string; downloadUrl?: string }>(url, {
     method: 'GET',
   });
 
-  if (typeof response === 'string') {
-    return response;
+  if (typeof response === 'string') return response;
+  if (response?.url || response?.downloadUrl) {
+    return response.url || response.downloadUrl!;
   }
-
-  if (response && (response.downloadUrl || response.url)) {
-    return response.downloadUrl || response.url;
-  }
-
   throw new Error('No download URL returned from API');
 }
 
-/** -------------------------------------------------------------------------
- * 🏗️ 4. Send approval e‑mail to client
- * --------------------------------------------------------------------------*/
-export const sendApprovalEmail = (projectId: string, recipientEmail: string) =>
-  request<{ message: string }>(`/send-approval-email`, {
-    method: 'POST',
-    body: JSON.stringify({ projectId, recipientEmail }),
-  });
+export const getS3DownloadUrl = getDownloadLink;
+export const getDownloadUrl = getDownloadLink;
 
+/** -----------------------------------------------------------------------
+ * Preview PDF helpers
+ * -------------------------------------------------------------------- */
+export async function previewPdfBackend(projectId: string): Promise<string> {
+  const data = await get<{ url: string }>(`${BASE}/preview-pdf/${projectId}`);
+  if (!data?.url) throw new Error('No preview URL returned from API');
+  return data.url;
+}
+
+export async function previewPdfViaS3(projectId: string): Promise<string> {
+  // Fallback: directly generate a signed URL via S3
+  return getS3PresignedUrl(`acta-${projectId}.pdf`);
+}
+
+/** -----------------------------------------------------------------------
+ * Send approval email
+ * -------------------------------------------------------------------- */
+export async function sendApprovalEmail(
+  projectId: string,
+  recipientEmail?: string,
+) {
+  const fallbackEmail =
+    recipientEmail ||
+    (process.env.VITE_APPROVAL_EMAIL as string | undefined) ||
+    (import.meta.env.VITE_APPROVAL_EMAIL as string | undefined);
+
+  if (!fallbackEmail) {
+    throw new Error('Please provide an email address for approval.');
+  }
+
+  return post<{ message: string }>(`${BASE}/send-approval-email`, {
+    projectId,
+    recipientEmail: fallbackEmail,
+  });
+}
+
+/** -----------------------------------------------------------------------
+ * Check document availability in S3
+ * -------------------------------------------------------------------- */
 export interface DocumentCheckResult {
   available: boolean;
   lastModified?: string;
@@ -151,37 +137,27 @@ export interface DocumentCheckResult {
   s3Key?: string;
 }
 
-/** -------------------------------------------------------------------------
- * 🏗️ 5. HEAD check → is document already in S3/CloudFront?
- * --------------------------------------------------------------------------*/
-export async function documentExists(
+export async function checkDocumentInS3(
   projectId: string,
-  format: 'pdf' | 'docx'
+  format: 'pdf' | 'docx',
 ): Promise<DocumentCheckResult> {
   try {
-    const url = `${BASE}/check-document/${projectId}?format=${format}`;
-    if (import.meta.env.DEV) {
-      console.log('🔍 Checking document:', url);
-    }
-    const response = await fetcher<DocumentCheckResult>(url, {
-      method: 'GET',
-    });
-
-    return {
-      available: true,
-      ...response,
-    };
-  } catch (error) {
-    console.warn('Document check failed:', error);
-    return {
-      available: false,
-    };
+    const data = await get<DocumentCheckResult>(
+      `${BASE}/check-document/${projectId}?format=${format}`,
+    );
+    return { available: true, ...data };
+  } catch (err) {
+    console.warn('Document check failed:', err);
+    return { available: false };
   }
 }
 
-/** -------------------------------------------------------------------------
- * ⭐ Additional ACTA Project Helpers
- * --------------------------------------------------------------------------*/
+export const checkDocumentAvailability = checkDocumentInS3;
+export const documentExists = checkDocumentInS3;
+
+/** -----------------------------------------------------------------------
+ * Project helpers
+ * -------------------------------------------------------------------- */
 export interface PMProject {
   id: string;
   name: string;
@@ -190,49 +166,42 @@ export interface PMProject {
   [k: string]: unknown;
 }
 
-export const checkDocumentInS3 = documentExists;
-export const getDownloadUrl = getS3DownloadUrl;
-export const checkDocumentAvailability = documentExists;
+export const getAllProjects = () => get<PMProject[]>(`${BASE}/all-projects`);
 
-export async function getProjectsByPM(pmEmail: string, isAdmin: boolean): Promise<PMProject[]> {
-  return request<PMProject[]>(
-    `/projects-for-pm?email=${encodeURIComponent(pmEmail)}&admin=${isAdmin}`
+// Additional project lookups used by other modules
+export const getProjectsByPM = (pmEmail: string, isAdmin: boolean) =>
+  get<PMProject[]>(
+    `${BASE}/projects-for-pm?email=${encodeURIComponent(pmEmail)}&admin=${isAdmin}`,
   );
-}
 
-export async function generateSummariesForPM(pmEmail: string): Promise<ProjectSummary[]> {
-  return request<ProjectSummary[]>(`/project-summaries?email=${encodeURIComponent(pmEmail)}`);
-}
+export const generateSummariesForPM = (pmEmail: string) =>
+  get<ProjectSummary[]>(
+    `${BASE}/project-summaries?email=${encodeURIComponent(pmEmail)}`,
+  );
 
-export async function getAllProjects(): Promise<PMProject[]> {
-  return request<PMProject[]>(`/all-projects`);
-}
+export const getProjectSummaryForPM = (projectId: string) =>
+  get<ProjectSummary>(`${BASE}/project-summary/${projectId}`);
 
-export async function getProjectSummaryForPM(projectId: string): Promise<ProjectSummary> {
-  return request<ProjectSummary>(`/project-summary/${projectId}`);
-}
+export const getPMProjectsWithSummary = (pmEmail: string) =>
+  get<ProjectSummary[]>(
+    `${BASE}/projects-with-summary?email=${encodeURIComponent(pmEmail)}`,
+  );
 
-export async function getPMProjectsWithSummary(pmEmail: string): Promise<ProjectSummary[]> {
-  return request<ProjectSummary[]>(`/projects-with-summary?email=${encodeURIComponent(pmEmail)}`);
-}
-
-/** -------------------------------------------------------------------------
- * 🧪 Dev Tools – expose helpers to browser
- * --------------------------------------------------------------------------*/
+/** -----------------------------------------------------------------------
+ * Dev helpers – expose functions for debugging
+ * -------------------------------------------------------------------- */
 if (import.meta.env.DEV && typeof window !== 'undefined') {
   // @ts-ignore
   window.__actaApi = {
-    ping: () => request<{ status: string }>('/health', { auth: false }),
     generateActaDocument,
-    getS3DownloadUrl,
-    documentExists,
+    getDownloadLink,
+    previewPdfBackend,
+    previewPdfViaS3,
     sendApprovalEmail,
+    checkDocumentInS3,
+    getAllProjects,
     getSummary,
     getTimeline,
-    getProjectsByPM,
-    generateSummariesForPM,
-    getAllProjects,
-    getProjectSummaryForPM,
-    getPMProjectsWithSummary,
   };
 }
+

--- a/src/utils/fetchWrapper.ts
+++ b/src/utils/fetchWrapper.ts
@@ -1,184 +1,89 @@
-// ✅ fetchWrapper.ts – Final Merge-Validated Version (CORS + CI Safe)
+// Lightweight fetch wrapper that attaches the current Cognito ID token
+// as a Bearer token and surfaces useful error messages. This version
+// intentionally avoids SigV4 signing – all requests rely solely on the
+// JWT provided by Amplify.
 
-import { Sha256 } from '@aws-crypto/sha256-js';
-import { FetchHttpHandler } from '@smithy/fetch-http-handler';
-import { HttpRequest } from '@smithy/protocol-http';
-import { SignatureV4 } from '@smithy/signature-v4';
-import { parseUrl } from '@smithy/url-parser';
 import { fetchAuthSession } from 'aws-amplify/auth';
 
 import { skipAuth } from '@/env.variables';
-
-const sigv4Endpoints = [
-  '/projects-for-pm',
-  '/send-approval-email',
-  '/check-document',
-  '/download-acta',
-  '/extract-project-place',
-  '/all-projects',
-];
-
-function needsSigV4(url: string): boolean {
-  if (typeof process !== 'undefined' && process.env.VITEST) {
-    return false;
-  }
-  return sigv4Endpoints.some((ep) => url.includes(ep));
-}
 
 export async function getAuthToken(): Promise<string | null> {
   if (skipAuth) {
     console.log('🔓 Skip auth mode: Using mock token');
     return 'mock-auth-token-skip-mode';
   }
+
   try {
-    console.log('🔐 Attempting to fetch auth session...');
     const session = await fetchAuthSession();
-    console.log('📡 Auth session response:', {
-      hasTokens: !!session.tokens,
-      hasIdToken: !!session.tokens?.idToken,
-      hasAccessToken: !!session.tokens?.accessToken,
-      credentials: !!session.credentials,
-    });
     const token = session.tokens?.idToken?.toString();
     if (token) {
-      console.log('✅ Successfully extracted ID token');
       return token;
-    } else {
-      console.warn('⚠️ No ID token found in session');
-      return null;
     }
+    console.warn('⚠️ No ID token found in session');
+    return null;
   } catch (error) {
     console.error('❌ Failed to fetch authentication session:', error);
     return null;
   }
 }
 
-export async function fetcher<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
+export async function fetcher<T>(input: RequestInfo, init: RequestInit = {}): Promise<T> {
   const url = typeof input === 'string' ? input : input.url;
   const token = await getAuthToken();
 
+  const headers = new Headers(init.headers);
+  if (token) headers.set('Authorization', `Bearer ${token}`);
+  if (!headers.has('Content-Type') && init.method && init.method !== 'GET') {
+    headers.set('Content-Type', 'application/json');
+  }
 
-  if (needsSigV4(url)) {
-    const token = await getAuthToken();
-    const session = await fetchAuthSession();
-    const creds = session.credentials;
+  const enhancedInit: RequestInit = {
+    ...init,
+    headers,
+    credentials: 'include',
+  };
 
-    const signer = new SignatureV4({
-      service: 'execute-api',
-      region: import.meta.env.VITE_AWS_REGION || import.meta.env.VITE_COGNITO_REGION || 'us-east-2',
-      credentials: {
-        accessKeyId: creds.accessKeyId,
-        secretAccessKey: creds.secretAccessKey,
-        sessionToken: creds.sessionToken,
-      },
-      sha256: Sha256,
-    });
+  console.log(`🌐 Fetching: ${url}`, {
+    method: enhancedInit.method || 'GET',
+    hasAuth: !!token,
+    headers: Object.fromEntries(headers.entries()),
+  });
 
-    const parsed = parseUrl(url);
-    const headerRecord: Record<string, string> = {
-      host: parsed.hostname,
-    };
+  const res = await fetch(url, enhancedInit);
 
-    if (token) {
-      headerRecord['Authorization'] = `Bearer ${token}`;
-    }
+  console.log(`📡 Response: ${res.status} ${res.statusText}`);
 
-    if (init?.headers) {
-      const headers = init.headers;
-      if (headers instanceof Headers) {
-        headers.forEach((value, key) => {
-          headerRecord[key] = value;
-        });
-      } else if (Array.isArray(headers)) {
-        headers.forEach(([key, value]) => {
-          headerRecord[key] = value;
-        });
-      } else if (typeof headers === 'object') {
-        Object.entries(headers).forEach(([key, value]) => {
-          headerRecord[key] = String(value);
-        });
-      }
-    }
-
-    const request = new HttpRequest({
-      ...parsed,
-      method: init?.method || 'GET',
-      headers: headerRecord,
-      body: init?.body,
-    });
-
-    const signed = (await signer.sign(request)) as HttpRequest;
-    const { response } = await new FetchHttpHandler().handle(signed);
-
-    const raw = await response.body?.transformToString();
+  if (!res.ok) {
+    let errorMessage = `HTTP ${res.status}: ${res.statusText}`;
     try {
-      const json = JSON.parse(raw ?? '');
-      console.log('✅ SigV4 Response:', json);
-      return json as T;
+      const errorText = await res.text();
+      if (errorText) errorMessage += ` - ${errorText}`;
     } catch {
-      console.error('❌ SigV4 response not JSON:', raw);
-      throw new Error('Invalid JSON response from SigV4 request');
+      // ignore
     }
-  } else {
-    const headers = new Headers(init?.headers);
-    if (token) headers.set('Authorization', `Bearer ${token}`);
-    if (!headers.has('Content-Type') && init?.method !== 'GET') {
-      headers.set('Content-Type', 'application/json');
-    }
+    console.error('❌ Fetch error:', errorMessage);
+    throw new Error(errorMessage);
+  }
 
-    const enhancedInit: RequestInit = {
-      ...init,
-      headers,
-      credentials: 'include',
-    };
-
-    console.log(`🌐 Fetching: ${url}`, {
-      method: enhancedInit.method || 'GET',
-      hasAuth: !!token,
-      headers: Object.fromEntries(headers.entries()),
-    });
-
-    const res = await fetch(url, enhancedInit);
-
-    console.log(`📡 Response: ${res.status} ${res.statusText}`);
-
-    if (!res.ok) {
-      let errorMessage = `HTTP ${res.status}: ${res.statusText}`;
-      try {
-        const errorText = await res.text();
-        if (errorText) errorMessage += ` - ${errorText}`;
-      } catch {
-        // Ignore parsing errors for error response text
-      }
-
-      if (res.status === 403) errorMessage += ' (Forbidden / Signature mismatch)';
-      if (res.status === 502) errorMessage += ' (Lambda error)';
-      if (res.status === 404) errorMessage += ' (Not Found)';
-
-      console.error('❌ Fetch error:', errorMessage);
-      throw new Error(errorMessage);
-    }
-
-    try {
-      const data = await res.json();
-      console.log('✅ Response data:', data);
-      return data as T;
-    } catch (error) {
-      console.error('❌ Failed to parse JSON response:', error);
-      throw new Error('Invalid JSON response from server');
-    }
+  try {
+    const data = await res.json();
+    console.log('✅ Response data:', data);
+    return data as T;
+  } catch (error) {
+    console.error('❌ Failed to parse JSON response:', error);
+    throw new Error('Invalid JSON response from server');
   }
 }
 
 export function get<T>(url: string): Promise<T> {
-  return fetcher<T>(url, { credentials: 'include' });
+  return fetcher<T>(url, { method: 'GET' });
 }
 
 export function post<T>(url: string, body?: unknown): Promise<T> {
   return fetcher<T>(url, {
     method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
     body: body !== undefined ? JSON.stringify(body) : undefined,
+    headers: { 'Content-Type': 'application/json' },
   });
 }
+


### PR DESCRIPTION
## Summary
- add production API helpers for generation, download, preview, approval email and S3 checks
- simplify fetch wrapper to use Cognito Bearer tokens with clearer error messages
- document loading guards on ACTA button component

## Testing
- `pnpm exec eslint . --fix`
- `pnpm exec tsc --noEmit`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895b18782448324a52b7de779cef95b