### PR TITLE
fix: Sort imports in DynamoProjectsView test file

### DIFF
--- a/src/components/__tests__/DynamoProjectsView.render.test.tsx
+++ b/src/components/__tests__/DynamoProjectsView.render.test.tsx
@@ -3,9 +3,8 @@
  */
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-
-import DynamoProjectsView, { Project } from '../DynamoProjectsView';
 import { getProjectsForCurrentUser } from '../../lib/awsDataService';
+import DynamoProjectsView, { Project } from '../DynamoProjectsView';
 
 vi.mock('../../lib/awsDataService');
 


### PR DESCRIPTION
This PR fixes the import sorting error in DynamoProjectsView.render.test.tsx:

- Reordered imports according to simple-import-sort/imports rule
- Moved getProjectsForCurrentUser import before DynamoProjectsView import
- Resolves CI lint error: 'Run autofix to sort these imports!'

This will allow the CI workflow to pass.